### PR TITLE
Feature/shortcut verify collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ public void IntParseTest() {
 
 より実践的には、下記のように利用します。
 ```cs
-// for MSTest v2
 [DataTestMethod]
 [DataRow(0, null, null, typeof(ArgumentNullException))]
 [DataRow(1, "123", 123, null)]
@@ -101,8 +100,8 @@ public void IntParseTest(int testNumber, string input, int expected, Type expect
         .Verify(expected, expectedExceptionType);
 }
 ```
+または
 ```cs
-// for MSTest v1
 [TestMethod]
 public void IntParseTest() {
     foreach (var item in TestCases()) {
@@ -118,7 +117,7 @@ public void IntParseTest() {
     };
 }
 ```
-`Run()` に渡されたテストコードの戻り値と `Verify()` の第１引数の比較方法ですが、 *MSTest* の場合 `Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual()` によって行われます。
+`Run()` に渡されたテストコードの戻り値と `Verify()` の第１引数の比較は、*MSTest* の場合 [Assert.AreEqual()](https://docs.microsoft.com/ja-jp/dotnet/api/microsoft.visualstudio.testtools.unittesting.assert.areequal?view=mstest-net-1.2.0) または [CollectionAssert.AreEqual()](https://docs.microsoft.com/ja-jp/dotnet/api/microsoft.visualstudio.testtools.unittesting.collectionassert.areequal?view=mstest-net-1.2.0) によって行われます。
 
 
 ## Licence

--- a/TestCaseRunner.Core.Tests/TestActualExtensionsTests.cs
+++ b/TestCaseRunner.Core.Tests/TestActualExtensionsTests.cs
@@ -40,8 +40,9 @@ namespace Inasync.Tests {
 
             // テストケース定義。
             (int testNumber, ITestActual<int> testActual, TestActualVerifier<int> resultVerifier, TestActualVerifier<Exception> exceptionVerifier, bool expectedResultVerifierCalled, bool expectedExceptionVerifierCalled, Type expectedExceptionType)[] TestCases() => new[]{
-                ( 0, TestActual( 0, null)                   , null            , ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
-                ( 1, TestActual( 0, null)                   , ResultVerifier(), null               , false, false, typeof(ArgumentNullException)),
+                ( 0, null                                   , ResultVerifier(), ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
+                ( 1, TestActual( 0, null)                   , null            , ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
+                ( 2, TestActual( 0, null)                   , ResultVerifier(), null               , false, false, typeof(ArgumentNullException)),
                 (10, TestActual( 0, null)                   , ResultVerifier(), ExceptionVerifier(), true , true , (Type)null),
                 (11, TestActual( 1, null)                   , ResultVerifier(), ExceptionVerifier(), true , true , (Type)null),
                 (12, TestActual(-1, null)                   , ResultVerifier(), ExceptionVerifier(), true , true , (Type)null),
@@ -87,14 +88,15 @@ namespace Inasync.Tests {
 
             // テストケース定義。
             (int testNumber, ITestActual testActual, TestActualVerifier resultVerifier, TestActualVerifier<Exception> exceptionVerifier, bool expectedResultVerifierCalled, bool expectedExceptionVerifierCalled, Type expectedExceptionType)[] TestCases() => new[]{
-                ( 0, TestActual(null)                   , null            , ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
-                ( 1, TestActual(null)                   , ResultVerifier(), null               , false, false, typeof(ArgumentNullException)),
+                ( 0, null                               , ResultVerifier(), ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
+                ( 1, TestActual(null)                   , null            , ExceptionVerifier(), false, false, typeof(ArgumentNullException)),
+                ( 2, TestActual(null)                   , ResultVerifier(), null               , false, false, typeof(ArgumentNullException)),
                 (10, TestActual(null)                   , ResultVerifier(), ExceptionVerifier(), true , true , (Type)null),
                 (11, TestActual(new Exception())        , ResultVerifier(), ExceptionVerifier(), false, true , (Type)null),
                 (12, TestActual(new ArgumentException()), ResultVerifier(), ExceptionVerifier(), false, true , (Type)null),
             };
 
-            ITestActual TestActual(Exception ex) => new TestCaseRunner("desc").Run(() => { if (ex != null) throw ex; });
+            ITestActual TestActual(Exception ex) => new TestCaseRunner("desc").Run(() => { if (ex != null) { throw ex; } });
             TestActualVerifier ResultVerifier() => (description) => { };
             TestActualVerifier<Exception> ExceptionVerifier() => (exception, description) => { };
         }

--- a/TestCaseRunner.Core.Tests/TestActualExtensionsTests.cs
+++ b/TestCaseRunner.Core.Tests/TestActualExtensionsTests.cs
@@ -12,11 +12,11 @@ namespace Inasync.Tests {
                 var message = $"No.{item.testNumber}";
 
                 var resultVerifierCalled = false;
-                var resultVerifierWrapper = (item.resultVerifier == null) ? (TestActualVerifier<int>)null : (result, description) => {
+                var resultVerifierWrapper = (item.resultVerifier == null) ? (TestActualVerifier<int>)null : (actual, description) => {
                     resultVerifierCalled = true;
-                    Assert.AreEqual(result, item.testActual.Result);
+                    Assert.AreEqual(actual, item.testActual.Result);
                     Assert.AreEqual(description, item.testActual.Description);
-                    item.resultVerifier(result, description);
+                    item.resultVerifier(actual, description);
                 };
                 var exceptionVerifierCalled = false;
                 var exceptionVerifierWrapper = (item.exceptionVerifier == null) ? (TestActualVerifier<Exception>)null : (exception, description) => {
@@ -50,7 +50,7 @@ namespace Inasync.Tests {
             };
 
             ITestActual<TResult> TestActual<TResult>(TResult result, Exception ex) => new TestCaseRunner("desc").Run(() => (ex == null) ? result : throw ex);
-            TestActualVerifier<int> ResultVerifier() => (result, description) => { };
+            TestActualVerifier<int> ResultVerifier() => (actual, description) => { };
             TestActualVerifier<Exception> ExceptionVerifier() => (exception, description) => { };
         }
 

--- a/TestCaseRunner.Core.Tests/Usage.cs
+++ b/TestCaseRunner.Core.Tests/Usage.cs
@@ -12,7 +12,7 @@ namespace Inasync.Tests {
                 new TestCaseRunner($"No.{item.testNumber}")
                     .Run(() => int.Parse(item.input))
                     .Verify(
-                        (result, description) => Assert.AreEqual(item.expected, result, description),
+                        (actual, description) => Assert.AreEqual(item.expected, actual, description),
                         (exception, description) => Assert.AreEqual(item.expectedExceptionType, exception?.GetType(), description)
                     );
             }

--- a/TestCaseRunner.Core/TestActual.cs
+++ b/TestCaseRunner.Core/TestActual.cs
@@ -2,6 +2,9 @@
 
 namespace Inasync {
 
+    /// <summary>
+    /// テスト結果を表す型。
+    /// </summary>
     public interface ITestActual {
 
         /// <summary>
@@ -10,15 +13,19 @@ namespace Inasync {
         string Description { get; }
 
         /// <summary>
-        /// テスト対象コードから生じた例外。
+        /// テスト中に生じた例外。
         /// </summary>
         Exception Exception { get; }
     }
 
+    /// <summary>
+    /// テスト結果を表す型。
+    /// </summary>
+    /// <typeparam name="TResult">テストの戻り値の型。</typeparam>
     public interface ITestActual<TResult> : ITestActual {
 
         /// <summary>
-        /// テスト対象コードの戻り値。
+        /// テストの戻り値。
         /// </summary>
         TResult Result { get; }
     }

--- a/TestCaseRunner.Core/TestActualExtensions.cs
+++ b/TestCaseRunner.Core/TestActualExtensions.cs
@@ -2,16 +2,20 @@
 
 namespace Inasync {
 
+    /// <summary>
+    /// <see cref="ITestActual{TResult}"/> の拡張クラス。
+    /// </summary>
     public static class TestActualExtensions {
 
         /// <summary>
-        /// テスト対象コードの実行結果を検証します。
+        /// テスト結果を検証します。
         /// </summary>
-        /// <param name="actual"></param>
-        /// <param name="resultVerifier">テスト対象コードの戻り値の検証を行うデリゲート。</param>
-        /// <param name="exceptionVerifier">テスト対象コードの例外の検証を行うデリゲート。</param>
-        /// <exception cref="ArgumentNullException"><paramref name="resultVerifier"/> or <paramref name="exceptionVerifier"/> is <c>null</c>.</exception>
+        /// <param name="actual">テスト結果。</param>
+        /// <param name="resultVerifier">テストの戻り値の検証を行うデリゲート。</param>
+        /// <param name="exceptionVerifier">テスト中に生じた例外の検証を行うデリゲート。</param>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/> or <paramref name="resultVerifier"/> or <paramref name="exceptionVerifier"/> is <c>null</c>.</exception>
         public static void Verify(this ITestActual actual, TestActualVerifier resultVerifier, TestActualVerifier<Exception> exceptionVerifier) {
+            if (actual == null) { throw new ArgumentNullException(nameof(actual)); }
             if (resultVerifier == null) { throw new ArgumentNullException(nameof(resultVerifier)); }
             if (exceptionVerifier == null) { throw new ArgumentNullException(nameof(exceptionVerifier)); }
 
@@ -25,14 +29,15 @@ namespace Inasync {
         }
 
         /// <summary>
-        /// テスト対象コードの実行結果を検証します。
+        /// テスト結果を検証します。
         /// </summary>
-        /// <typeparam name="TResult">テスト対象コードの戻り値の型。</typeparam>
-        /// <param name="actual"></param>
-        /// <param name="resultVerifier">テスト対象コードの戻り値の検証を行うデリゲート。</param>
-        /// <param name="exceptionVerifier">テスト対象コードの例外の検証を行うデリゲート。</param>
-        /// <exception cref="ArgumentNullException"><paramref name="resultVerifier"/> or <paramref name="exceptionVerifier"/> is <c>null</c>.</exception>
+        /// <typeparam name="TResult">テストの戻り値の型。</typeparam>
+        /// <param name="actual">テスト結果。</param>
+        /// <param name="resultVerifier">テストの戻り値の検証を行うデリゲート。</param>
+        /// <param name="exceptionVerifier">テスト中に生じた例外の検証を行うデリゲート。</param>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/> or <paramref name="resultVerifier"/> or <paramref name="exceptionVerifier"/> is <c>null</c>.</exception>
         public static void Verify<TResult>(this ITestActual<TResult> actual, TestActualVerifier<TResult> resultVerifier, TestActualVerifier<Exception> exceptionVerifier) {
+            if (actual == null) { throw new ArgumentNullException(nameof(actual)); }
             if (resultVerifier == null) { throw new ArgumentNullException(nameof(resultVerifier)); }
             if (exceptionVerifier == null) { throw new ArgumentNullException(nameof(exceptionVerifier)); }
 

--- a/TestCaseRunner.Core/TestActualVerifier.cs
+++ b/TestCaseRunner.Core/TestActualVerifier.cs
@@ -1,13 +1,13 @@
 ﻿namespace Inasync {
 
     /// <summary>
-    /// テスト対象コードの実行結果を検証するデリゲート。
+    /// テスト結果を検証するデリゲート。
     /// </summary>
     /// <param name="description">テストの説明。</param>
     public delegate void TestActualVerifier(string description);
 
     /// <summary>
-    /// テスト対象コードの実行結果を検証するデリゲート。
+    /// テスト結果を検証するデリゲート。
     /// </summary>
     /// <typeparam name="TActual"><paramref name="actual" /> の型。</typeparam>
     /// <param name="actual">検証対象のオブジェクト。</param>

--- a/TestCaseRunner.Core/TestCaseRunner.cs
+++ b/TestCaseRunner.Core/TestCaseRunner.cs
@@ -8,7 +8,7 @@ namespace Inasync {
     public struct TestCaseRunner {
 
         /// <summary>
-        /// <see cref="TestCaseRunner"/> のコンストラクター。
+        /// <see cref="TestCaseRunner"/> を作成します。
         /// </summary>
         /// <param name="description">テストの説明。</param>
         public TestCaseRunner(string description) {
@@ -24,7 +24,7 @@ namespace Inasync {
         /// 対象コードのテストを実施します。
         /// </summary>
         /// <typeparam name="TResult">対象コードの戻り値の型。</typeparam>
-        /// <param name="targetCode">テストの対象コード。</param>
+        /// <param name="targetCode">テスト対象のコード。</param>
         /// <returns>対象コードの実行結果。</returns>
         /// <exception cref="ArgumentNullException"><paramref name="targetCode"/> is <c>null</c>.</exception>
         public ITestActual<TResult> Run<TResult>(Func<TResult> targetCode) {
@@ -42,7 +42,7 @@ namespace Inasync {
         /// <summary>
         /// 対象コードのテストを実施します。
         /// </summary>
-        /// <param name="targetCode">テストの対象コード。</param>
+        /// <param name="targetCode">テスト対象のコード。</param>
         /// <returns>対象コードの実行結果。</returns>
         /// <exception cref="ArgumentNullException"><paramref name="targetCode"/> is <c>null</c>.</exception>
         public ITestActual Run(Action targetCode) {

--- a/TestCaseRunner.MSTest.Tests/TestActualExtensionsTests.cs
+++ b/TestCaseRunner.MSTest.Tests/TestActualExtensionsTests.cs
@@ -51,11 +51,11 @@ namespace Inasync.Tests {
                 var message = $"No.{item.testNumber}";
 
                 var resultVerifierCalled = false;
-                var resultVerifierWrapper = (item.resultVerifier == null) ? (TestActualVerifier<int>)null : (result, description) => {
+                var resultVerifierWrapper = (item.resultVerifier == null) ? (TestActualVerifier<int>)null : (actual, description) => {
                     resultVerifierCalled = true;
-                    Assert.AreEqual(result, item.testActual.Result);
+                    Assert.AreEqual(actual, item.testActual.Result);
                     Assert.AreEqual(description, item.testActual.Description);
-                    item.resultVerifier(result, description);
+                    item.resultVerifier(actual, description);
                 };
 
                 try {

--- a/TestCaseRunner.MSTest.Tests/TestActualExtensionsTests.cs
+++ b/TestCaseRunner.MSTest.Tests/TestActualExtensionsTests.cs
@@ -138,6 +138,7 @@ namespace Inasync.Tests {
                 (16, TestActual(Objs(0, "").AsEnumerable(), new Exception())        , Objs(0, ""), typeof(Exception)        , (Type)null),
                 (17, TestActual(Objs(0, "").AsEnumerable(), new Exception())        , Objs(0, ""), typeof(ArgumentException), (Type)typeof(AssertFailedException)),
                 (18, TestActual(Objs(0, "").AsEnumerable(), new ArgumentException()), Objs(0, ""), typeof(ArgumentException), (Type)null),
+                (19, TestActual(Objs(0, "").AsEnumerable(), null)                   , null       , null                     , (Type)typeof(AssertFailedException)),
             };
 
             object[] Objs(params object[] objs) => objs;

--- a/TestCaseRunner.MSTest/TestActualExtensions.cs
+++ b/TestCaseRunner.MSTest/TestActualExtensions.cs
@@ -45,8 +45,10 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
             Inasync.TestActualExtensions.Verify(
                   actual
                 , (result, description) => {
-                    if (typeof(TResult) != typeof(string) && expectedResult is IEnumerable expectedResults) {
-                        CollectionAssert.AreEqual(expectedResults?.Cast<object>().ToArray(), (result as IEnumerable)?.Cast<object>().ToArray(), description);
+                    if (typeof(TResult) != typeof(string) && actual.Result is IEnumerable actualResults) {
+                        var actualCollection = actualResults.Cast<object>().ToArray();
+                        var expectedCollection = (expectedResult as IEnumerable)?.Cast<object>().ToArray();
+                        CollectionAssert.AreEqual(expectedCollection, actualCollection, description);
                     }
                     else {
                         Assert.AreEqual(expectedResult, result, description);

--- a/TestCaseRunner.MSTest/TestActualExtensions.cs
+++ b/TestCaseRunner.MSTest/TestActualExtensions.cs
@@ -3,49 +3,47 @@ using Inasync;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting {
 
+    /// <summary>
+    /// <see cref="ITestActual{TResult}"/> の拡張クラス。
+    /// </summary>
     public static class TestActualExtensions {
 
         /// <summary>
-        /// テスト対象コードの実行結果を検証します。
+        /// テスト結果を検証します。
         /// </summary>
-        /// <param name="actual">テスト対象コードの実行結果。</param>
-        /// <param name="resultVerifier">テスト対象コードの戻り値の検証を行うデリゲート。</param>
-        /// <param name="expectedExceptionType">テスト対象コードによって生じる事が期待される例外の型。</param>
+        /// <param name="actual">テスト結果。</param>
+        /// <param name="resultVerifier">テストの戻り値の検証を行うデリゲート。</param>
+        /// <param name="expectedExceptionType">テスト中に生じる事が期待される例外の型。</param>
         /// <exception cref="ArgumentNullException"><paramref name="actual"/> or <paramref name="resultVerifier"/> is <c>null</c>.</exception>
         public static void Verify(this ITestActual actual, TestActualVerifier resultVerifier, Type expectedExceptionType) {
-            if (actual == null) { throw new ArgumentNullException(nameof(actual)); }
-
-            actual.Verify(resultVerifier, CreateDefaultExceptionVerifier(expectedExceptionType));
+            Inasync.TestActualExtensions.Verify(actual, resultVerifier, CreateDefaultExceptionVerifier(expectedExceptionType));
         }
 
         /// <summary>
-        /// テスト対象コードの実行結果を検証します。
+        /// テスト結果を検証します。
         /// </summary>
-        /// <typeparam name="TResult">テスト対象コードの戻り値の型。</typeparam>
-        /// <param name="actual">テスト対象コードの実行結果。</param>
-        /// <param name="resultVerifier">テスト対象コードの戻り値の検証を行うデリゲート。</param>
-        /// <param name="expectedExceptionType">テスト対象コードによって生じる事が期待される例外の型。</param>
+        /// <typeparam name="TResult">テストの戻り値の型。</typeparam>
+        /// <param name="actual">テスト結果。</param>
+        /// <param name="resultVerifier">テストの戻り値の検証を行うデリゲート。</param>
+        /// <param name="expectedExceptionType">テスト中に生じる事が期待される例外の型。</param>
         /// <exception cref="ArgumentNullException"><paramref name="actual"/> or <paramref name="resultVerifier"/> is <c>null</c>.</exception>
         public static void Verify<TResult>(this ITestActual<TResult> actual, TestActualVerifier<TResult> resultVerifier, Type expectedExceptionType) {
-            if (actual == null) { throw new ArgumentNullException(nameof(actual)); }
-
-            actual.Verify(resultVerifier, CreateDefaultExceptionVerifier(expectedExceptionType));
+            Inasync.TestActualExtensions.Verify(actual, resultVerifier, CreateDefaultExceptionVerifier(expectedExceptionType));
         }
 
         /// <summary>
-        /// テスト対象コードの実行結果を検証します。
+        /// テスト結果を検証します。
         /// </summary>
-        /// <typeparam name="TResult">テスト対象コードの戻り値の型。</typeparam>
-        /// <param name="actual">テスト対象コードの実行結果。</param>
-        /// <param name="expectedResult">テスト対象コードの戻り値として期待される値。</param>
-        /// <param name="expectedExceptionType">テスト対象コードによって生じる事が期待される例外の型。</param>
-        /// <exception cref="ArgumentNullException"><paramref name="actual"/> or <paramref name="resultVerifier"/> is <c>null</c>.</exception>
+        /// <typeparam name="TResult">テストの戻り値の型。</typeparam>
+        /// <param name="actual">テスト結果。</param>
+        /// <param name="expectedResult">テストの戻り値として期待される値。</param>
+        /// <param name="expectedExceptionType">テスト中に生じる事が期待される例外の型。</param>
+        /// <exception cref="ArgumentNullException"><paramref name="actual"/> is <c>null</c>.</exception>
         public static void Verify<TResult>(this ITestActual<TResult> actual, TResult expectedResult, Type expectedExceptionType) {
-            if (actual == null) { throw new ArgumentNullException(nameof(actual)); }
-
-            actual.Verify(
-                (result, description) => Assert.AreEqual(expectedResult, result, description),
-                CreateDefaultExceptionVerifier(expectedExceptionType)
+            Inasync.TestActualExtensions.Verify(
+                  actual
+                , (result, description) => Assert.AreEqual(expectedResult, result, description)
+                , CreateDefaultExceptionVerifier(expectedExceptionType)
             );
         }
 
@@ -55,7 +53,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
         /// 既定の例外検証を行う <see cref="TestActualVerifier{TActual}"/> を作成します。
         /// </summary>
         /// <param name="expectedExceptionType">テスト時に期待する例外の型。</param>
-        /// <returns>例外検証を行う <see cref="TestActualVerifier{TActual}"/> デリゲート。</returns>
+        /// <returns>例外検証を行う <see cref="TestActualVerifier{TActual}"/> デリゲート。常に非 <c>null</c>。</returns>
         private static TestActualVerifier<Exception> CreateDefaultExceptionVerifier(Type expectedExceptionType) => (Exception exception, string description) => {
             try {
                 Assert.AreEqual(expectedExceptionType, exception?.GetType(), description);

--- a/TestCaseRunner.MSTest/TestActualExtensions.cs
+++ b/TestCaseRunner.MSTest/TestActualExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Linq;
 using Inasync;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting {
@@ -42,7 +44,14 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
         public static void Verify<TResult>(this ITestActual<TResult> actual, TResult expectedResult, Type expectedExceptionType) {
             Inasync.TestActualExtensions.Verify(
                   actual
-                , (result, description) => Assert.AreEqual(expectedResult, result, description)
+                , (result, description) => {
+                    if (typeof(TResult) != typeof(string) && expectedResult is IEnumerable expectedResults) {
+                        CollectionAssert.AreEqual(expectedResults?.Cast<object>().ToArray(), (result as IEnumerable)?.Cast<object>().ToArray(), description);
+                    }
+                    else {
+                        Assert.AreEqual(expectedResult, result, description);
+                    }
+                }
                 , CreateDefaultExceptionVerifier(expectedExceptionType)
             );
         }

--- a/TestCaseRunner.MSTest/TestCaseRunner.MSTest.csproj
+++ b/TestCaseRunner.MSTest/TestCaseRunner.MSTest.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/in-async/TestCaseRunner</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/in-async/TestCaseRunner/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>test unittest mstest</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,6 @@ deploy:
     appveyor_repo_tag: true
 - provider: NuGet
   api_key:
-    secure: 0OZfy83MivYusS7hh4l6FKku+l6FyQvu+OCssQgjMf5sB1FtVf/3FHkHAo9TXJpM
+    secure: GilxmLH2LKBej3PApN7lwlElta8LfVgqXsryn94cRjr3/FP0dIvS3gEOpJv2Pe2q
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
## Changelogs
- *TestCaseRunner.MSTest* のバージョンを 1.1.0 に更新。
- `ITestActual.Verify()` の検証対象が `IEnumerable` の場合にコレクション比較となるよう対応。
- ドキュメントコメントを修正。

## Todo
- [x] Code Coverage の確認。
- [x] マージ前の Nuget 確認。